### PR TITLE
Sorteer updates op datum

### DIFF
--- a/weather.station.server/weather.station.server/Controllers/WeatherUpdatesController.cs
+++ b/weather.station.server/weather.station.server/Controllers/WeatherUpdatesController.cs
@@ -40,7 +40,10 @@ namespace weather.station.server.Controllers
             }
 
             //Truncating time in the query.
-            var updatesWithingTimeSpan = await _context.WeatherUpdate.Where(u => fromDate.Date <= u.TimeStamp.Date && toDate.Date >= u.TimeStamp.Date).ToListAsync();
+            var updatesWithingTimeSpan = await _context.WeatherUpdate
+                .Where(u => fromDate.Date <= u.TimeStamp.Date && toDate.Date >= u.TimeStamp.Date)
+                .OrderByDescending(u => u.TimeStamp)
+                .ToListAsync();
 
             return Ok(updatesWithingTimeSpan);
         }
@@ -90,7 +93,10 @@ namespace weather.station.server.Controllers
             }
 
             //Truncating time in the query.
-            var updatesFromDevice = await _context.WeatherUpdate.Where(u => u.DeviceId == id && fromDate.Date <= u.TimeStamp.Date && toDate.Date >= u.TimeStamp.Date).ToListAsync();
+            var updatesFromDevice = await _context.WeatherUpdate
+                .Where(u => u.DeviceId == id && fromDate.Date <= u.TimeStamp.Date && toDate.Date >= u.TimeStamp.Date)
+                .OrderByDescending(u => u.TimeStamp)
+                .ToListAsync();
 
             return Ok(updatesFromDevice);
         }


### PR DESCRIPTION
## Samenvatting van wijzingen
Deze PR zorgt ervoor dat de weerudpates altijd worden gesorteerd op `TimeStamp`. Hierdoor staat de nieuwste update altijd bovenaan.

## Test instructies
Voeg meerdere updates toe en controleer of deze gesorteerd staan op `TimeStamp` van oud naar nieuw.
