### PR TITLE
Rate limit requests based on IP and deviceId

### DIFF
--- a/weather.station.server/weather.station.server/Controllers/Api/WeatherUpdatesController.cs
+++ b/weather.station.server/weather.station.server/Controllers/Api/WeatherUpdatesController.cs
@@ -133,7 +133,7 @@ namespace weather.station.server.Controllers.Api
         // POST: api/WeatherUpdates
         // Adds an update to the database
         [HttpPost]
-        // [RateLimit(300)]
+        [RateLimit(300)]
         public async Task<IActionResult> PostWeatherUpdate([FromBody] WeatherUpdate weatherUpdate)
         {
             if (!ModelState.IsValid)


### PR DESCRIPTION
## Samenvatting van wijzigingen
Deze PR zorgt ervoor dat een user zijn `deviceId` mee kan sturen in de header `X-Device-Id`. Op deze manier kan de rate limiting op basis van Ip + deviceId geregeld worden. Dit maakt het mogelijk om met meerdere weerstations vanaf één ip address weerdata te uploaden.

Closes #25 

