### PR TITLE
Add link to dashboard to map popup

### DIFF
--- a/weather.station.server/weather.station.server/Views/Home/Index.cshtml
+++ b/weather.station.server/weather.station.server/Views/Home/Index.cshtml
@@ -21,7 +21,7 @@
         {
             <script>
                 var text =
-                    "<strong>@latestUpdate.Device.DeviceName</strong><p>Temperatuur: @latestUpdate.TemperatureC C <br>Windsnelheid: @latestUpdate.Windspeed KMH <br>Luchtvochtigheid: @latestUpdate.Humidity %";
+                    "<strong>@latestUpdate.Device.DeviceName</strong><p>Temperatuur: @latestUpdate.TemperatureC C <br>Windsnelheid: @latestUpdate.Windspeed KMH <br>Luchtvochtigheid: @latestUpdate.Humidity %<br /><a href='/dashboard/@latestUpdate.Device.DeviceId'>Open dashboard</a>";
                 var popup = new mapboxgl.Popup({ offset: 25 })
                     .setHTML(text);
 


### PR DESCRIPTION
## Samenvatting van wijzigingen
Deze PR voegt een link toe aan de popup van de weerstations op de kaart. Op deze manier krijgt het dashboard wat meer waarde en is het makkelijker om van een specifiek weerstation de weerdata in te zien:
![image](https://user-images.githubusercontent.com/2659866/48301199-2c35be80-e4ea-11e8-9c55-a35a87f259ba.png)

