### PR TITLE
Prevent error when inserting 'NaN' values

### DIFF
--- a/weather.station.server/weather.station.server/Controllers/Api/WeatherUpdatesController.cs
+++ b/weather.station.server/weather.station.server/Controllers/Api/WeatherUpdatesController.cs
@@ -148,6 +148,9 @@ namespace weather.station.server.Controllers.Api
 
             weatherUpdate.TimeStamp = DateTime.UtcNow;
             weatherUpdate.WeatherUpdateId = Guid.NewGuid();
+            weatherUpdate.Humidity = double.IsNaN(weatherUpdate.Humidity) ? 0 : weatherUpdate.Humidity;
+            weatherUpdate.TemperatureC = double.IsNaN(weatherUpdate.TemperatureC) ? 0 : weatherUpdate.TemperatureC;
+            weatherUpdate.Windspeed = double.IsNaN(weatherUpdate.Windspeed) ? 0 : weatherUpdate.Windspeed;
 
             _context.WeatherUpdate.Add(weatherUpdate);
             await _context.SaveChangesAsync();


### PR DESCRIPTION
## Samenvatting van wijzigingen
Deze PR voegt een controle toe voor `NaN` values. Als er nu zo een value wordt gepost resulteert dit in een 500 error. Zie #55 
