### PR TITLE
Center the map on NL

### DIFF
--- a/weather.station.server/weather.station.server/wwwroot/js/weatherstationmap.js
+++ b/weather.station.server/weather.station.server/wwwroot/js/weatherstationmap.js
@@ -4,6 +4,6 @@
 var map = new mapboxgl.Map({
     container: 'map2',
     style: 'mapbox://styles/mapbox/streets-v9',
-    center: [5, 52],
-    zoom: 7
+    center: [5, 52.1],
+    zoom: 6.2
 });


### PR DESCRIPTION
## Samenvatting van wijzigingen
Deze PR zorgt ervoor dat de kaart standaard op Nederland staat gencentreerd i.p.v. regio Rotterdam